### PR TITLE
fix: Add priceId to Stripe checkout request to resolve subscription p…

### DIFF
--- a/src/app/subscription/page.tsx
+++ b/src/app/subscription/page.tsx
@@ -231,6 +231,7 @@ export default function SubscriptionPage() {
         },
         body: JSON.stringify({
           planType,
+          priceId: PRODUCTS.PRO.priceId,
           successUrl: `${window.location.origin}/subscription?success=true`,
           cancelUrl: `${window.location.origin}/subscription?canceled=true`,
         }),


### PR DESCRIPTION
## Stripe Subscription Fix

### What Changed
- Added `priceId` parameter to the Stripe checkout request in `subscription/page.tsx`
- This fixes the "Failed to start subscription process" error by properly passing the required price ID to the checkout endpoint

### Why
The subscription process was failing because the checkout endpoint required a `priceId` parameter, but it wasn't being sent in the request. This caused a 400 (Bad Request) error when users tried to subscribe.

### Testing
- Verified subscription process works locally
- Tested with both test and production Stripe keys
- Confirmed successful checkout flow and webhook handling

### Impact
Users can now successfully subscribe to the Pro plan through the Stripe checkout process.